### PR TITLE
fix: mongodb protocol support in .env and mongodb connection

### DIFF
--- a/models/mongodb/connector.js
+++ b/models/mongodb/connector.js
@@ -16,7 +16,7 @@ module.exports = exports = function (config) {
 
     hosts.forEach((host, index) => {
         if (index == 0) {
-            databaseUrl += `mongodb://${host}:${ports[0]}`;
+            databaseUrl += `${process.env.MONGODB_PROTOCOL || "mongodb://"}${host}:${ports[0]}`;
         } else {
             databaseUrl += `,${host}:${ports[index]}`;
         }


### PR DESCRIPTION
I find an issue in the MongoDB Atlas connection string

eg: mongodb+srv://<username>:<password>cluster0.dry7s.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0

in code, mongodb:// is hardcoded so I can not use MongoDB atlas 